### PR TITLE
introduce back go-junit-report for parsing go test output

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -613,7 +613,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     )
     cmds, tools = _go_binary_cmds(static=static, definitions=definitions, gcov=cgo)
 
-    test_cmd = f'$TEST {flags} 2>&1 | tee $TMP_DIR/test.results'
+    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT -skipped-node-text-location message-attr | tee $RESULTS_FILE'
     worker_cmd = f'$(worker {worker})' if worker else ""
     if worker_cmd:
         test_cmd = f'{worker_cmd} && {test_cmd} '
@@ -646,6 +646,9 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         debug_tools = debug_tools,
         cmd = cmds,
         test_cmd = test_cmd,
+        test_tools = {
+            "junit_report": "//third_party/go:junit_report",
+        },
         debug_cmd = debug_cmd,
         visibility = visibility,
         test_sandbox = sandbox,

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -613,7 +613,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     )
     cmds, tools = _go_binary_cmds(static=static, definitions=definitions, gcov=cgo)
 
-    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT -skipped-node-text-location message-attr | tee $RESULTS_FILE'
+    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT | tee $RESULTS_FILE'
     worker_cmd = f'$(worker {worker})' if worker else ""
     if worker_cmd:
         test_cmd = f'{worker_cmd} && {test_cmd} '

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -45,6 +45,21 @@ go_module(
     visibility = ["PUBLIC"],
 )
 
+go_mod_download(
+    name = "junit_report_download",
+    module = "github.com/marcuscaisey/go-junit-report/v2",
+    version = "b576769f22db5b6a7880775f723c0b29e5a03ac7",
+)
+
+go_module(
+    name = "junit_report",
+    binary = True,
+    download = ":junit_report_download",
+    licences = ["MIT"],
+    module = "github.com/jstemmer/go-junit-report/v2",
+    visibility = ["PUBLIC"],
+)
+
 go_module(
     name = "spew",
     install = ["spew"],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -48,7 +48,7 @@ go_module(
 go_mod_download(
     name = "junit_report_download",
     module = "github.com/marcuscaisey/go-junit-report/v2",
-    version = "b576769f22db5b6a7880775f723c0b29e5a03ac7",
+    version = "f9f65c7e2eb4a7e4a98b4cc8757772ae1092d211",
 )
 
 go_module(


### PR DESCRIPTION
**Stacked on https://github.com/please-build/go-rules/pull/81**

The test output from `go_test` is currently quite hard to read and also can be inaccurate. 

For example, given this test file:
```go
package foo_test

import (
	"fmt"
	"os"
	"testing"

	"github.com/stretchr/testify/assert"
)

func Test(t *testing.T) {
	fmt.Fprintln(os.Stdout, "Test stdout")
	fmt.Fprintln(os.Stderr, "Test stderr")
	assert.Equal(t, 1, 2, "Test failure")

	t.Run("Subtest1", func(t *testing.T) {
		fmt.Fprintln(os.Stdout, "Subtest1 stdout")
		fmt.Fprintln(os.Stderr, "Subtest1 stderr")
		assert.Equal(t, 1, 2, "Subtest1 failure")

		t.Run("NestedSubtest", func(t *testing.T) {
			fmt.Fprintln(os.Stdout, "NestedSubtest stdout")
			fmt.Fprintln(os.Stderr, "NestedSubtest stderr")
			assert.Equal(t, 1, 2, "NestedSubtest failure")
		})
	})

	t.Run("Subtest2", func(t *testing.T) {
		fmt.Fprintln(os.Stdout, "Subtest2 stdout")
		fmt.Fprintln(os.Stderr, "Subtest2 stderr")
		assert.Equal(t, 1, 2, "Subtest2 failure")
	})
}
```

we get the following output:

```
00:11:06.488   ERROR: //foo:test failed
Fail: //foo:test   0 passed   0 skipped   4 failed   0 errored Took 60ms
Failure:  in Test
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure
Standard error:
Test stdout
Test stderr
    foo_test.go:14: 
        	Error Trace:	foo_test.go:14
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test
        	Messages:   	Test failure
Subtest1 stdout
Subtest1 stderr
    foo_test.go:19: 
        	Error Trace:	foo_test.go:19
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest1
        	Messages:   	Subtest1 failure
NestedSubtest stdout
NestedSubtest stderr
    foo_test.go:24: 
        	Error Trace:	foo_test.go:24
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest1/NestedSubtest
        	Messages:   	NestedSubtest failure
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure

Failure:  in Test/Subtest1
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure
--- FAIL: Test (0.00s)
Failure:  in Test/Subtest1/NestedSubtest
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure
--- FAIL: Test (0.00s)
    --- FAIL: Test/Subtest1 (0.00s)
Failure:  in Test/Subtest2
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure
--- FAIL: Test (0.00s)
    --- FAIL: Test/Subtest1 (0.00s)
        --- FAIL: Test/Subtest1/NestedSubtest (0.00s)
//foo:test 4 tests run in 62ms; 0 passed, 4 failed
    Test                         FAIL  0s
    Test/Subtest1                FAIL  0s
    Test/Subtest1/NestedSubtest  FAIL  0s
    Test/Subtest2                FAIL  0s
1 test target and 4 tests run; 0 passed, 4 failed.
Total time: 100ms real, 60ms compute.
```

There are 4 assertions which fail, however 8 assertion failures are shown. All 4 expected assertions are output under `Standard error` header and then an assertion failure is also output for each failing test / subtest. However, the assertion failures under each `Failure:  in XXX` header are not the correct failures. Instead, the failure from `Test/Subtest2` is output each time.

I can see that `go-junit-report` `v0.9.0` (technically a couple of commits after this tag) was introduced to the Please repo in 2020 and then reverted due to it not being able to handle more complex input (https://github.com/thought-machine/please/pull/995). This PR introduces it back, now that the tool seems to have matured a bit. Between `v0.9.0` and `v2.0.0`, 81 test cases have been added and it seems to pass the eye test on the above test file:

```
00:47:04.082   ERROR: //foo:test failed: Failed
Fail: //foo:test   0 passed   0 skipped   4 failed   0 errored Took 70ms
Failure:  in Test
Failed
Test stdout
Test stderr
    foo_test.go:14: 
        	Error Trace:	foo_test.go:14
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test
        	Messages:   	Test failure
Failure:  in Test/Subtest1
Failed
Subtest1 stdout
Subtest1 stderr
    foo_test.go:19: 
        	Error Trace:	foo_test.go:19
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest1
        	Messages:   	Subtest1 failure
Failure:  in Test/Subtest1/NestedSubtest
Failed
NestedSubtest stdout
NestedSubtest stderr
    foo_test.go:24: 
        	Error Trace:	foo_test.go:24
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest1/NestedSubtest
        	Messages:   	NestedSubtest failure
Failure:  in Test/Subtest2
Failed
Subtest2 stdout
Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test/Subtest2
        	Messages:   	Subtest2 failure
//foo:test 4 tests run in 68ms; 0 passed, 4 failed
    Test                         FAIL  0s
    Test/Subtest1                FAIL  0s
    Test/Subtest1/NestedSubtest  FAIL  0s
    Test/Subtest2                FAIL  0s
1 test target and 4 tests run; 0 passed, 4 failed.
Total time: 110ms real, 70ms compute.
```

Now, only 4 assertion failures are output and each one is under the correct `Failure:  in XXX` heading. 

The version that i've added to this repo is my fork where i've set the message attribute of the `<skipped>` node correctly so that the reason is output correctly by Please (without this change, the skipped test output looks like `Reason: Skipped` vs `Reason: external_test.go:32: Failing on Alpine currently`). I've made a PR to upstream this: https://github.com/jstemmer/go-junit-report/pull/158.

I'm happy to throw any other test files you can think of at `go-junit-report` to make sure it handles them properly 🙏 